### PR TITLE
Update QA tool for RxNorm releases

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>UMLS Release QA</title>
+  <title>RxNorm Release QA</title>
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
   <div class="container">
-    <h1 id="page-title" class="editable">UMLS Release QA</h1>
+    <h1 id="page-title" class="editable">RxNorm Release QA</h1>
     <div class="admin-controls">
       <button id="admin-toggle" class="editable">Admin Mode</button>
       <button id="save-texts" class="editable" style="display:none">Save</button>
@@ -31,8 +31,8 @@
         }
       } catch {}
       texts = texts || {};
-      document.title = texts.title || 'UMLS Release QA';
-      document.getElementById('page-title').textContent = texts.header || 'UMLS Release QA';
+      document.title = texts.title || 'RxNorm Release QA';
+      document.getElementById('page-title').textContent = texts.header || 'RxNorm Release QA';
       document.getElementById('run-preprocess').textContent = texts.runPreprocessButton || 'Run Preprocessing';
       document.getElementById('compare-lines').textContent = texts.compareLinesButton || 'Compare Line Counts';
       adminToggle.textContent = texts.adminToggleOff || 'Admin Mode';
@@ -115,7 +115,7 @@
         } else {
           status.innerHTML = `
             <p style="color:red">Could not find at least two release folders.</p>
-            <p>Please download the UMLS Metathesaurus Full Subset for the two latest releases and copy the complete contents after unzipping into the <code>releases</code> folder.</p>
+            <p>Please download the RxNorm full release files for the two latest versions and copy the <code>rrf</code> folders into the <code>releases</code> directory.</p>
           `;
         }
       } catch (err) {

--- a/js/tests/checkReleases.js
+++ b/js/tests/checkReleases.js
@@ -19,7 +19,7 @@ export async function run({ ui }) {
     if (current && previous) {
       ui.appendSummary(`<p style="color:green">✅ Current release: ${current}, Previous release: ${previous}</p>`);
     } else {
-      ui.appendSummary('<p style="color:red">❌ Could not find at least two releases (with META folders) in the releases directory.</p>');
+      ui.appendSummary('<p style="color:red">❌ Could not find at least two releases (with rrf folders) in the releases directory.</p>');
     }
   } catch (err) {
     ui.appendSummary(`<p style="color:red">Error checking releases: ${err.message}</p>`);

--- a/preprocess.js
+++ b/preprocess.js
@@ -18,7 +18,7 @@ async function detectReleases() {
         const stat = await fsp.stat(full);
         if (stat.isDirectory()) {
           const subEntries = await fsp.readdir(full);
-          if (subEntries.some(d => d.toLowerCase() === 'meta')) {
+          if (subEntries.some(d => d.toLowerCase() === 'rrf')) {
             releaseList.push(entry);
           }
         }
@@ -58,8 +58,8 @@ async function listFiles(dir, base = dir) {
 }
 
 async function generateLineCountDiff(current, previous) {
-  const currentMeta = path.join(releasesDir, current, 'META');
-  const previousMeta = path.join(releasesDir, previous, 'META');
+  const currentMeta = path.join(releasesDir, current, 'rrf');
+  const previousMeta = path.join(releasesDir, previous, 'rrf');
   const result = [];
   const currFiles = await listFiles(currentMeta).catch(() => []);
   const prevFiles = await listFiles(previousMeta).catch(() => []);
@@ -224,8 +224,8 @@ function buildDiffData(sab, tty, baseRows, prevRows) {
 }
 
 async function generateSABDiff(current, previous) {
-  const currentFile = path.join(releasesDir, current, 'META', 'MRCONSO.RRF');
-  const previousFile = path.join(releasesDir, previous, 'META', 'MRCONSO.RRF');
+  const currentFile = path.join(releasesDir, current, 'rrf', 'MRCONSO.RRF');
+  const previousFile = path.join(releasesDir, previous, 'rrf', 'MRCONSO.RRF');
   const baseCounts = await readCountsMRCONSO(currentFile);
   const prevCounts = await readCountsMRCONSO(previousFile);
 
@@ -278,8 +278,8 @@ async function generateSABDiff(current, previous) {
 }
 
 async function generateCountReport(current, previous, fileName, indices, tableName) {
-  const currentFile = path.join(releasesDir, current, 'META', fileName);
-  const previousFile = path.join(releasesDir, previous, 'META', fileName);
+  const currentFile = path.join(releasesDir, current, 'rrf', fileName);
+  const previousFile = path.join(releasesDir, previous, 'rrf', fileName);
   const baseCounts = await readCountsByIndices(currentFile, indices);
   const prevCounts = await readCountsByIndices(previousFile, indices);
   const summary = [];

--- a/server.js
+++ b/server.js
@@ -7,8 +7,8 @@ const fsp = fs.promises;
 const reportsDir = path.join(__dirname, 'reports');
 const textsFile = path.join(__dirname, 'texts.json');
 const defaultTexts = {
-  title: 'UMLS Release QA',
-  header: 'UMLS Release QA',
+  title: 'RxNorm Release QA',
+  header: 'RxNorm Release QA',
   runPreprocessButton: 'Run Preprocessing',
   compareLinesButton: 'Compare Line Counts',
   adminToggleOff: 'Admin Mode',
@@ -38,7 +38,7 @@ async function detectReleases() {
         const stat = await fsp.stat(full);
         if (stat.isDirectory()) {
           const subEntries = await fsp.readdir(full);
-          if (subEntries.some(d => d.toLowerCase() === 'meta')) {
+          if (subEntries.some(d => d.toLowerCase() === 'rrf')) {
             releaseList.push(entry);
           }
         }
@@ -186,8 +186,8 @@ app.get('/api/line-count-diff', async (req, res) => {
     return;
   } catch {}
 
-  const currentMeta = path.join(releasesDir, current, 'META');
-  const previousMeta = path.join(releasesDir, previous, 'META');
+  const currentMeta = path.join(releasesDir, current, 'rrf');
+  const previousMeta = path.join(releasesDir, previous, 'rrf');
   const result = [];
 
   try {


### PR DESCRIPTION
## Summary
- update default site text and instructions for RxNorm
- detect `rrf` folders instead of `META`
- look for RxNorm data under `rrf/` in preprocessing and server routes
- adjust release-folder warning message for RxNorm

## Testing
- `node preprocess.js` *(fails: Need at least two releases in releases/)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686538c9269883278137107cc6091219